### PR TITLE
[Bugfix] Model name result displayed on print

### DIFF
--- a/tools/buffalo/model/generator.go
+++ b/tools/buffalo/model/generator.go
@@ -34,7 +34,6 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 		return ErrModelDirNotFound
 	}
 
-	name := flect.Singularize(args[2])
 	filename := flect.Singularize(flect.Underscore(args[2]))
 
 	if g.exists(filepath.Join(dirPath, filename+".go")) {
@@ -46,7 +45,7 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 		return errors.Wrap(err, "creating models error")
 	}
 
-	fmt.Printf("[info] Model generated in: \n-- app/models/%s.go\n-- app/models/%s_test.go\n", name, name)
+	fmt.Printf("[info] Model generated in: \n-- app/models/%s.go\n-- app/models/%s_test.go\n", filename, filename)
 
 	return nil
 }


### PR DESCRIPTION
This PR fixes a small bug where the result of the model generation was displaying the wrong filename.
When typing "ox generate model somethingCamelized" the terminal is displaying
```
[info] Model generated in: 
-- app/models/somethingCamelized.go
-- app/models/somethingCamelized_test.go
```
Instead of:
```
[info] Model generated in: 
-- app/models/something_camelized.go
-- app/models/something_camelized.go
```